### PR TITLE
Arm reset / home pose method and click to hold (gripper)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ __pycache__/
 *$py.class
 
 *.py~
-
+xArm-Python-SDK/
 # C extensions
 *.so
 

--- a/example.py
+++ b/example.py
@@ -1,6 +1,6 @@
 import time
-from env.xarm_env import XArmEnv
-from env.xarm_config import XArmConfig
+from robot_env.xarm_env import XArmEnv
+from robot_env.xarm_config import XArmConfig
 from controller.spacemouse_config import SpaceMouseConfig
 from controller.spacemouse_controller import SpaceMouse
 
@@ -12,6 +12,8 @@ spacemouse = SpaceMouse(spacemouse_cfg)
 
 control_loop_rate = xarm_cfg.control_loop_rate
 control_loop_period = 1.0 / control_loop_rate
+
+xarm_env._arm_reset()
 
 try:
     while True:
@@ -28,8 +30,7 @@ try:
         time.sleep(sleep_time)
 except KeyboardInterrupt:
     print("Teleop manually shut down!")
+    xarm_env._arm_reset()
 except Exception as e:
     print(f"An error occurred: {e}")
-
-
-
+    xarm_env._arm_reset()

--- a/robot_env/xarm_config.py
+++ b/robot_env/xarm_config.py
@@ -1,18 +1,24 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import List
 
 @dataclass
 class XArmConfig:
     """
     Configuration class for some (not all!) xArm7/control parameters. The important ones are here.
-    You can or should change most of these to your liking, potentially with the exception of tcp_maxacc
+    You can or should change most of these to your liking, potentially with the exception of tcp_maxacc.
 
     :config_param tcp_maxacc: TCP (Tool Center Point, i.e., end effector) maximum acceleration
     :config_param position_gain: Increasing this value makes the position gain increase
     :config_param orientation_gain: Increasing this value makes the orientation gain increase
     :config_param alpha: This is a pseudo-smoothing factor
     :config_param control_loop_rate: Self-descriptive
-    :config_param ip: ip of the robot; alternative to setting in robot.conf
-    :config verbose: Helpful debugging / checking print steps
+    :config_param ip: IP of the robot; alternative to setting in robot.conf
+    :config_param home_pos: The home/default position of the robot arm
+    :config_param home_speed: How fast the robot arm should move when reseting
+    :config_param gripper_speed: How fast the gripper should be opening and closing
+    :config_param gripper_open: position of the open gripper (do not change unless really necessary!)
+    :config_param gripper_closed: position of the closed gripper (do not change unless really necessary!)
+    :config_param verbose: Helpful debugging / checking print steps
     """
     tcp_maxacc: int = 5000
     position_gain: float = 10.0
@@ -20,4 +26,9 @@ class XArmConfig:
     alpha: float = 0.5
     control_loop_rate: int = 50
     ip: str = '192.168.1.223'
+    home_pos: List[int] = field(default_factory=lambda: [0, 0, 0, 70, 0, 70, 0])
+    home_speed: float = 50.0
+    gripper_speed: int = 1000
+    gripper_open: int = 850
+    gripper_closed: int = 0
     verbose: bool = True


### PR DESCRIPTION
Two main updates:
1. Added a way to reset the arm (xarmenv._arm_reset()). You can see how this works by running example.py
2. Instead of holding down the button on spacemouse in order to grab, you just click once to hold and then click again to open.

What's left (beyond what is already in TODO/more urgent):
1. Make holding the click button on spacemouse hold and letting go open (original behavior)
2. Fix orientation (?)
4. We should hide the extra parameters we are passing into step. We should make it so we can access spacemouse member variables, pass in the controller object once into xarm_env and be done. Then leave it as xarmenv.step(*kwargs) so we don't need to explicitly pass things in unless we want/need to.
5. Fixing relative imports (this should be easy...)
6. Update the readme so others can install as needed (also should be easy...)